### PR TITLE
Implement dry run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#12] implement maintenance mode
 - [#17] add health checks before and after applying the blueprint
 - [#20] Add exception for `nginx` dependency validation. Map this dependency to `nginx-ingress` and `nginx-static`.
+- [#22] Add `dryRun` option. If `dryRun` is active the blueprint procedure stops before applying resources to the cluster and remains in the actual state. One can set the option to false and continue at this state.
+  

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,8 @@ include build/make/mocks.mk
 K8S_COMPONENT_SOURCE_VALUES = ${HELM_SOURCE_DIR}/values.yaml
 K8S_COMPONENT_TARGET_VALUES = ${HELM_TARGET_DIR}/values.yaml
 PRE_COMPILE=generate-deepcopy
-HELM_PRE_APPLY_TARGETS=template-stage template-log-level template-image-pull-policy
 HELM_PRE_GENERATE_TARGETS = helm-values-update-image-version
-HELM_POST_GENERATE_TARGETS = helm-values-replace-image-repo
+HELM_POST_GENERATE_TARGETS = helm-values-replace-image-repo template-stage template-log-level template-image-pull-policy
 CRD_POST_MANIFEST_TARGETS = crd-add-labels
 CHECK_VAR_TARGETS=check-all-vars
 IMAGE_IMPORT_TARGET=image-import

--- a/k8s/helm-crd/templates/k8s.cloudogu.com_blueprints.yaml
+++ b/k8s/helm-crd/templates/k8s.cloudogu.com_blueprints.yaml
@@ -42,6 +42,9 @@ spec:
                 blueprintMask:
                   description: BlueprintMask json can further restrict the desired state from the blueprint.
                   type: string
+                dryRun:
+                  description: DryRun lets the user test a blueprint run to check if all attributes of the blueprint are correct and avoid a result with a failure state.
+                  type: boolean
                 ignoreDoguHealth:
                   description: IgnoreDoguHealth lets the user execute the blueprint even if dogus are unhealthy at the moment.
                   type: boolean

--- a/pkg/adapter/kubernetes/blueprintSpecCRRepository.go
+++ b/pkg/adapter/kubernetes/blueprintSpecCRRepository.go
@@ -78,6 +78,7 @@ func (repo *blueprintSpecRepo) GetById(ctx context.Context, blueprintId string) 
 		Config: domain.BlueprintConfiguration{
 			IgnoreDoguHealth:         blueprintCR.Spec.IgnoreDoguHealth,
 			AllowDoguNamespaceSwitch: blueprintCR.Spec.AllowDoguNamespaceSwitch,
+			DryRun:                   blueprintCR.Spec.DryRun,
 		},
 		Status: blueprintCR.Status.Phase,
 	}

--- a/pkg/adapter/kubernetes/blueprintSpecCRRepository_test.go
+++ b/pkg/adapter/kubernetes/blueprintSpecCRRepository_test.go
@@ -29,7 +29,7 @@ func Test_blueprintSpecRepo_GetById(t *testing.T) {
 	blueprintId := "MyBlueprint"
 
 	t.Run("all ok", func(t *testing.T) {
-		//given
+		// given
 		restClientMock := NewMockBlueprintInterface(t)
 		eventRecorderMock := newMockEventRecorder(t)
 		repo := NewBlueprintSpecRepository(restClientMock, blueprintV2.Serializer{}, blueprintMaskV1.Serializer{}, eventRecorderMock)
@@ -42,15 +42,16 @@ func Test_blueprintSpecRepo_GetById(t *testing.T) {
 				BlueprintMask:            `{"blueprintMaskAPI": "v1"}`,
 				AllowDoguNamespaceSwitch: true,
 				IgnoreDoguHealth:         true,
+				DryRun:                   true,
 			},
 			Status: v1.BlueprintStatus{},
 		}
 		restClientMock.EXPECT().Get(ctx, blueprintId, metav1.GetOptions{}).Return(cr, nil)
 
-		//when
+		// when
 		spec, err := repo.GetById(ctx, blueprintId)
 
-		//then
+		// then
 		require.NoError(t, err)
 		persistenceContext := make(map[string]interface{})
 		persistenceContext[blueprintSpecRepoContextKey] = blueprintSpecRepoContext{"abc"}
@@ -59,6 +60,7 @@ func Test_blueprintSpecRepo_GetById(t *testing.T) {
 			Config: domain.BlueprintConfiguration{
 				IgnoreDoguHealth:         true,
 				AllowDoguNamespaceSwitch: true,
+				DryRun:                   true,
 			},
 			EffectiveBlueprint: domain.EffectiveBlueprint{
 				RegistryConfig:          domain.RegistryConfig{},
@@ -70,7 +72,7 @@ func Test_blueprintSpecRepo_GetById(t *testing.T) {
 	})
 
 	t.Run("invalid blueprint and mask", func(t *testing.T) {
-		//given
+		// given
 		restClientMock := NewMockBlueprintInterface(t)
 		eventRecorderMock := newMockEventRecorder(t)
 		repo := NewBlueprintSpecRepository(restClientMock, blueprintV2.Serializer{}, blueprintMaskV1.Serializer{}, eventRecorderMock)
@@ -86,10 +88,10 @@ func Test_blueprintSpecRepo_GetById(t *testing.T) {
 		}
 		restClientMock.EXPECT().Get(ctx, blueprintId, metav1.GetOptions{}).Return(cr, nil)
 
-		//when
+		// when
 		_, err := repo.GetById(ctx, blueprintId)
 
-		//then
+		// then
 		require.Error(t, err)
 		var expectedErrorType *domain.InvalidBlueprintError
 		assert.ErrorAs(t, err, &expectedErrorType)
@@ -99,17 +101,17 @@ func Test_blueprintSpecRepo_GetById(t *testing.T) {
 	})
 
 	t.Run("internal error while loading", func(t *testing.T) {
-		//given
+		// given
 		restClientMock := NewMockBlueprintInterface(t)
 		eventRecorderMock := newMockEventRecorder(t)
 		repo := NewBlueprintSpecRepository(restClientMock, blueprintV2.Serializer{}, blueprintMaskV1.Serializer{}, eventRecorderMock)
 
 		restClientMock.EXPECT().Get(ctx, blueprintId, metav1.GetOptions{}).Return(nil, k8sErrors.NewInternalError(errors.New("test-error")))
 
-		//when
+		// when
 		_, err := repo.GetById(ctx, blueprintId)
 
-		//then
+		// then
 		require.Error(t, err)
 		var expectedErrorType *domainservice.InternalError
 		assert.ErrorAs(t, err, &expectedErrorType)
@@ -118,7 +120,7 @@ func Test_blueprintSpecRepo_GetById(t *testing.T) {
 	})
 
 	t.Run("not found error while loading", func(t *testing.T) {
-		//given
+		// given
 		restClientMock := NewMockBlueprintInterface(t)
 		eventRecorderMock := newMockEventRecorder(t)
 		repo := NewBlueprintSpecRepository(restClientMock, blueprintV2.Serializer{}, blueprintMaskV1.Serializer{}, eventRecorderMock)
@@ -127,10 +129,10 @@ func Test_blueprintSpecRepo_GetById(t *testing.T) {
 			Get(ctx, blueprintId, metav1.GetOptions{}).
 			Return(nil, k8sErrors.NewNotFound(schema.GroupResource{}, blueprintId))
 
-		//when
+		// when
 		_, err := repo.GetById(ctx, blueprintId)
 
-		//then
+		// then
 		require.Error(t, err)
 		var expectedErrorType *domainservice.NotFoundError
 		assert.ErrorAs(t, err, &expectedErrorType)
@@ -142,7 +144,7 @@ func Test_blueprintSpecRepo_Update(t *testing.T) {
 	blueprintId := "MyBlueprint"
 
 	t.Run("all ok", func(t *testing.T) {
-		//given
+		// given
 		restClientMock := NewMockBlueprintInterface(t)
 		eventRecorderMock := newMockEventRecorder(t)
 		repo := NewBlueprintSpecRepository(restClientMock, blueprintV2.Serializer{}, blueprintMaskV1.Serializer{}, eventRecorderMock)
@@ -172,7 +174,7 @@ func Test_blueprintSpecRepo_Update(t *testing.T) {
 				return blueprint, nil
 			})
 
-		//when
+		// when
 		persistenceContext := make(map[string]interface{})
 		persistenceContext[blueprintSpecRepoContextKey] = blueprintSpecRepoContext{"abc"}
 		err := repo.Update(ctx, &domain.BlueprintSpec{
@@ -182,35 +184,35 @@ func Test_blueprintSpecRepo_Update(t *testing.T) {
 			PersistenceContext: persistenceContext,
 		})
 
-		//then
+		// then
 		require.NoError(t, err)
 	})
 
 	t.Run("no version counter", func(t *testing.T) {
-		//given
+		// given
 		restClientMock := NewMockBlueprintInterface(t)
 		eventRecorderMock := newMockEventRecorder(t)
 		repo := NewBlueprintSpecRepository(restClientMock, blueprintV2.Serializer{}, blueprintMaskV1.Serializer{}, eventRecorderMock)
 
-		//when
+		// when
 		err := repo.Update(ctx, &domain.BlueprintSpec{
 			Id:     blueprintId,
 			Status: domain.StatusPhaseValidated,
 			Events: nil,
 		})
 
-		//then
+		// then
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "no blueprintSpecRepoContext was provided over the persistenceContext in the given blueprintSpec")
 	})
 
 	t.Run("version counter of different type", func(t *testing.T) {
-		//given
+		// given
 		restClientMock := NewMockBlueprintInterface(t)
 		eventRecorderMock := newMockEventRecorder(t)
 		repo := NewBlueprintSpecRepository(restClientMock, blueprintV2.Serializer{}, blueprintMaskV1.Serializer{}, eventRecorderMock)
 
-		//when
+		// when
 		persistenceContext := make(map[string]interface{})
 		persistenceContext[blueprintSpecRepoContextKey] = 1
 		err := repo.Update(ctx, &domain.BlueprintSpec{
@@ -220,13 +222,13 @@ func Test_blueprintSpecRepo_Update(t *testing.T) {
 			PersistenceContext: persistenceContext,
 		})
 
-		//then
+		// then
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "ersistence context in blueprintSpec is not a 'blueprintSpecRepoContext' but 'int'")
 	})
 
 	t.Run("conflict error", func(t *testing.T) {
-		//given
+		// given
 		restClientMock := NewMockBlueprintInterface(t)
 		eventRecorderMock := newMockEventRecorder(t)
 		repo := NewBlueprintSpecRepository(restClientMock, blueprintV2.Serializer{}, blueprintMaskV1.Serializer{}, eventRecorderMock)
@@ -261,7 +263,7 @@ func Test_blueprintSpecRepo_Update(t *testing.T) {
 				return nil, expectedError
 			})
 
-		//when
+		// when
 		persistenceContext := make(map[string]interface{})
 		persistenceContext[blueprintSpecRepoContextKey] = blueprintSpecRepoContext{"abc"}
 		err := repo.Update(ctx, &domain.BlueprintSpec{
@@ -271,7 +273,7 @@ func Test_blueprintSpecRepo_Update(t *testing.T) {
 			PersistenceContext: persistenceContext,
 		})
 
-		//then
+		// then
 		require.Error(t, err)
 		var expectedErrorType *domainservice.ConflictError
 		assert.ErrorAs(t, err, &expectedErrorType)
@@ -279,7 +281,7 @@ func Test_blueprintSpecRepo_Update(t *testing.T) {
 	})
 
 	t.Run("internal error", func(t *testing.T) {
-		//given
+		// given
 		restClientMock := NewMockBlueprintInterface(t)
 		eventRecorderMock := newMockEventRecorder(t)
 		repo := NewBlueprintSpecRepository(restClientMock, blueprintV2.Serializer{}, blueprintMaskV1.Serializer{}, eventRecorderMock)
@@ -310,7 +312,7 @@ func Test_blueprintSpecRepo_Update(t *testing.T) {
 				return nil, expectedError
 			})
 
-		//when
+		// when
 		persistenceContext := make(map[string]interface{})
 		persistenceContext[blueprintSpecRepoContextKey] = blueprintSpecRepoContext{"abc"}
 		err := repo.Update(ctx, &domain.BlueprintSpec{
@@ -320,7 +322,7 @@ func Test_blueprintSpecRepo_Update(t *testing.T) {
 			PersistenceContext: persistenceContext,
 		})
 
-		//then
+		// then
 		require.Error(t, err)
 		var expectedErrorType *domainservice.InternalError
 		assert.ErrorAs(t, err, &expectedErrorType)
@@ -331,14 +333,14 @@ func Test_blueprintSpecRepo_Update(t *testing.T) {
 func Test_blueprintSpecRepo_Update_publishEvents(t *testing.T) {
 	blueprintId := "MyBlueprint"
 	t.Run("publish events", func(t *testing.T) {
-		//given
+		// given
 		restClientMock := NewMockBlueprintInterface(t)
 		eventRecorderMock := newMockEventRecorder(t)
 		repo := NewBlueprintSpecRepository(restClientMock, blueprintV2.Serializer{}, blueprintMaskV1.Serializer{}, eventRecorderMock)
 		restClientMock.EXPECT().
 			UpdateStatus(ctx, mock.Anything, metav1.UpdateOptions{}).
 			RunAndReturn(func(ctx2 context.Context, blueprint *v1.Blueprint, options metav1.UpdateOptions) (*v1.Blueprint, error) {
-				//assert.Equal(t, &expected, blueprint)
+				// assert.Equal(t, &expected, blueprint)
 				blueprint.ResourceVersion = "newVersion"
 				return blueprint, nil
 			})
@@ -361,13 +363,13 @@ func Test_blueprintSpecRepo_Update_publishEvents(t *testing.T) {
 		eventRecorderMock.EXPECT().Event(mock.Anything, corev1.EventTypeNormal, "EcosystemUnhealthyUpfront", "ecosystem is unhealthy: 0 dogus are unhealthy: ")
 		eventRecorderMock.EXPECT().Event(mock.Anything, corev1.EventTypeNormal, "BlueprintSpecInvalid", "test-error")
 
-		//when
+		// when
 		persistenceContext := make(map[string]interface{})
 		persistenceContext[blueprintSpecRepoContextKey] = blueprintSpecRepoContext{"abc"}
 		spec := &domain.BlueprintSpec{Id: blueprintId, Events: events, PersistenceContext: persistenceContext}
 		err := repo.Update(ctx, spec)
 
-		//then
+		// then
 		require.NoError(t, err)
 		newPersistenceContext, _ := getPersistenceContext(ctx, spec)
 		assert.Equal(t, "newVersion", newPersistenceContext.resourceVersion)

--- a/pkg/api/v1/blueprint_types.go
+++ b/pkg/api/v1/blueprint_types.go
@@ -21,6 +21,8 @@ type BlueprintSpec struct {
 	// AllowDoguNamespaceSwitch lets the user switch the namespace of dogus in the blueprint mask
 	// in comparison to the blueprint.
 	AllowDoguNamespaceSwitch bool `json:"allowDoguNamespaceSwitch,omitempty"`
+	// DryRun lets the user test a blueprint run to check if all attributes of the blueprint are correct and avoid a result with a failure state.
+	DryRun bool `json:"dryRun,omitempty"`
 }
 
 // BlueprintStatus defines the observed state of Blueprint
@@ -34,8 +36,8 @@ type BlueprintStatus struct {
 	StateDiff stateDiffV1.StateDiffV1 `json:"stateDiff,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Blueprint is the Schema for the blueprints API
 type Blueprint struct {
@@ -48,7 +50,7 @@ type Blueprint struct {
 	Status BlueprintStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // BlueprintList contains a list of Blueprint
 type BlueprintList struct {

--- a/pkg/application/applyBlueprintSpecUseCase.go
+++ b/pkg/application/applyBlueprintSpecUseCase.go
@@ -102,6 +102,11 @@ func (useCase *ApplyBlueprintSpecUseCase) ApplyBlueprintSpec(ctx context.Context
 
 	if blueprintSpec.Config.DryRun {
 		logger.Info("skip applying states to the cluster because the blueprint is in dry run mode")
+		blueprintSpec.Events = append(blueprintSpec.Events, domain.BlueprintDryRunEvent{})
+		updateErr := useCase.repo.Update(ctx, blueprintSpec)
+		if updateErr != nil {
+			return updateErr
+		}
 		return nil
 	}
 

--- a/pkg/application/applyBlueprintSpecUseCase_test.go
+++ b/pkg/application/applyBlueprintSpecUseCase_test.go
@@ -186,6 +186,22 @@ func TestApplyBlueprintSpecUseCase_ApplyBlueprintSpec(t *testing.T) {
 		assert.Equal(t, domain.StatusPhaseBlueprintApplied, spec.Status)
 	})
 
+	t.Run("should do nothing and return nil on dry run", func(t *testing.T) {
+		spec := &domain.BlueprintSpec{
+			Config: domain.BlueprintConfiguration{
+				DryRun: true,
+			},
+		}
+		repoMock := newMockBlueprintSpecRepository(t)
+		repoMock.EXPECT().GetById(testCtx, "blueprintId").Return(spec, nil).Times(1)
+
+		useCase := ApplyBlueprintSpecUseCase{repo: repoMock, doguInstallUseCase: nil}
+
+		err := useCase.ApplyBlueprintSpec(testCtx, "blueprintId")
+
+		require.NoError(t, err)
+	})
+
 	t.Run("cannot load spec", func(t *testing.T) {
 		repoMock := newMockBlueprintSpecRepository(t)
 		repoMock.EXPECT().GetById(testCtx, "blueprintId").Return(nil, assert.AnError)
@@ -206,8 +222,8 @@ func TestApplyBlueprintSpecUseCase_ApplyBlueprintSpec(t *testing.T) {
 		repoMock.EXPECT().GetById(testCtx, "blueprintId").Return(spec, nil)
 		repoMock.EXPECT().Update(testCtx, spec).Return(assert.AnError)
 
-		//installUseCaseMock := newMockDoguInstallationUseCase(t)
-		//installUseCaseMock.EXPECT().ApplyDoguStates(testCtx, "blueprintId").Return(nil)
+		// installUseCaseMock := newMockDoguInstallationUseCase(t)
+		// installUseCaseMock.EXPECT().ApplyDoguStates(testCtx, "blueprintId").Return(nil)
 		useCase := ApplyBlueprintSpecUseCase{repo: repoMock, doguInstallUseCase: nil}
 
 		err := useCase.ApplyBlueprintSpec(testCtx, "blueprintId")

--- a/pkg/application/applyBlueprintSpecUseCase_test.go
+++ b/pkg/application/applyBlueprintSpecUseCase_test.go
@@ -33,10 +33,11 @@ func TestApplyBlueprintSpecUseCase_markInProgress(t *testing.T) {
 		installUseCaseMock := newMockDoguInstallationUseCase(t)
 		useCase := ApplyBlueprintSpecUseCase{repo: repoMock, doguInstallUseCase: installUseCaseMock}
 
-		err := useCase.markInProgress(testCtx, spec)
+		shouldApply, err := useCase.startApplying(testCtx, spec)
 
 		require.NoError(t, err)
 		assert.Equal(t, domain.StatusPhaseInProgress, spec.Status)
+		assert.True(t, shouldApply)
 	})
 
 	t.Run("repo error", func(t *testing.T) {
@@ -49,10 +50,11 @@ func TestApplyBlueprintSpecUseCase_markInProgress(t *testing.T) {
 		installUseCaseMock := newMockDoguInstallationUseCase(t)
 		useCase := ApplyBlueprintSpecUseCase{repo: repoMock, doguInstallUseCase: installUseCaseMock}
 
-		err := useCase.markInProgress(testCtx, spec)
+		shouldApply, err := useCase.startApplying(testCtx, spec)
 
 		require.ErrorIs(t, err, assert.AnError)
 		assert.Equal(t, domain.StatusPhaseInProgress, spec.Status)
+		assert.False(t, shouldApply)
 	})
 }
 
@@ -224,7 +226,8 @@ func TestApplyBlueprintSpecUseCase_ApplyBlueprintSpec(t *testing.T) {
 		err := useCase.ApplyBlueprintSpec(testCtx, "blueprintId")
 
 		require.Error(t, err)
-		assert.ErrorIs(t, assert.AnError, err)
+		assert.ErrorIs(t, err, assert.AnError)
+		assert.ErrorContains(t, err, "cannot mark blueprint as in progress")
 	})
 
 	t.Run("cannot load spec", func(t *testing.T) {

--- a/pkg/application/blueprintSpecChangeUseCase.go
+++ b/pkg/application/blueprintSpecChangeUseCase.go
@@ -62,7 +62,7 @@ func (useCase *BlueprintSpecChangeUseCase) HandleChange(ctx context.Context, blu
 	// without any error, the blueprint spec is always ready to be further evaluated, therefore call this function again to do that.
 	switch blueprintSpec.Status {
 	case domain.StatusPhaseNew:
-		return useCase.handleNew(ctx, blueprintId, blueprintSpec)
+		return useCase.validateStatically(ctx, blueprintId)
 	case domain.StatusPhaseInvalid:
 		return nil
 	case domain.StatusPhaseStaticallyValidated:
@@ -97,24 +97,6 @@ func (useCase *BlueprintSpecChangeUseCase) HandleChange(ctx context.Context, blu
 	default:
 		return fmt.Errorf("could not handle unknown status of blueprint")
 	}
-}
-
-func (useCase *BlueprintSpecChangeUseCase) handleNew(ctx context.Context, blueprintId string, blueprintSpec *domain.BlueprintSpec) error {
-	err := useCase.addPotentialDryRunEvent(ctx, blueprintSpec)
-	if err != nil {
-		return fmt.Errorf("failed adding dry run event: %w", err)
-	}
-
-	return useCase.validateStatically(ctx, blueprintId)
-}
-
-func (useCase *BlueprintSpecChangeUseCase) addPotentialDryRunEvent(ctx context.Context, blueprintSpec *domain.BlueprintSpec) error {
-	if !blueprintSpec.Config.DryRun {
-		return nil
-	}
-	blueprintSpec.Events = append(blueprintSpec.Events, domain.BlueprintDryRunEvent{})
-
-	return useCase.repo.Update(ctx, blueprintSpec)
 }
 
 func (useCase *BlueprintSpecChangeUseCase) validateStatically(ctx context.Context, blueprintId string) error {

--- a/pkg/domain/blueprintSpec.go
+++ b/pkg/domain/blueprintSpec.go
@@ -275,9 +275,15 @@ func (spec *BlueprintSpec) CheckEcosystemHealthAfterwards(healthResult ecosystem
 	}
 }
 
-func (spec *BlueprintSpec) MarkInProgress() {
-	spec.Status = StatusPhaseInProgress
-	spec.Events = append(spec.Events, InProgressEvent{})
+func (spec *BlueprintSpec) StartApplying() (shouldApply bool) {
+	if spec.Config.DryRun {
+		spec.Events = append(spec.Events, BlueprintDryRunEvent{})
+	} else {
+		spec.Status = StatusPhaseInProgress
+		spec.Events = append(spec.Events, InProgressEvent{})
+		shouldApply = true
+	}
+	return
 }
 
 func (spec *BlueprintSpec) MarkFailed(err error) {

--- a/pkg/domain/blueprintSpec.go
+++ b/pkg/domain/blueprintSpec.go
@@ -59,8 +59,10 @@ const (
 type BlueprintConfiguration struct {
 	// Force blueprint upgrade even when a dogu is unhealthy
 	IgnoreDoguHealth bool
-	// allowNamespaceSwitch allows the blueprint upgrade to switch a dogus namespace
+	// AllowDoguNamespaceSwitch allows the blueprint upgrade to switch a dogus namespace
 	AllowDoguNamespaceSwitch bool
+	// DryRun lets the user test a blueprint run to check if all attributes of the blueprint are correct and avoid a result with a failure state.
+	DryRun bool
 }
 
 type BlueprintUpgradePlan struct {
@@ -83,10 +85,10 @@ type BlueprintUpgradePlan struct {
 // or nil otherwise.
 func (spec *BlueprintSpec) ValidateStatically() error {
 	switch spec.Status {
-	case StatusPhaseNew: //continue
-	case StatusPhaseInvalid: //do not validate again
+	case StatusPhaseNew: // continue
+	case StatusPhaseInvalid: // do not validate again
 		return &InvalidBlueprintError{Message: "blueprint spec was marked invalid before: do not revalidate"}
-	default: //do not validate again. for all other status it must be either status validated or a status beyond that
+	default: // do not validate again. for all other status it must be either status validated or a status beyond that
 		return nil
 	}
 	var errorList []error
@@ -154,12 +156,12 @@ func (spec *BlueprintSpec) ValidateDynamically(possibleInvalidDependenciesError 
 func (spec *BlueprintSpec) CalculateEffectiveBlueprint() error {
 	switch spec.Status {
 	case StatusPhaseEffectiveBlueprintGenerated:
-		return nil //do not regenerate effective blueprint
+		return nil // do not regenerate effective blueprint
 	case StatusPhaseNew: // stop
 		return fmt.Errorf("cannot calculate effective blueprint before the blueprint spec is validated")
 	case StatusPhaseInvalid: // stop
 		return fmt.Errorf("cannot calculate effective blueprint on invalid blueprint spec")
-	default: //continue: StatusPhaseValidated, StatusPhaseInProgress, StatusPhaseFailed, StatusPhaseCompleted
+	default: // continue: StatusPhaseValidated, StatusPhaseInProgress, StatusPhaseFailed, StatusPhaseCompleted
 	}
 
 	effectiveDogus, err := spec.calculateEffectiveDogus()

--- a/pkg/domain/blueprintSpec_test.go
+++ b/pkg/domain/blueprintSpec_test.go
@@ -484,16 +484,43 @@ func TestBlueprintSpec_CheckEcosystemHealthAfterwards(t *testing.T) {
 	}
 }
 
-func TestBlueprintSpec_MarkInProgress(t *testing.T) {
-	// given
-	spec := &BlueprintSpec{}
-	// when
-	spec.MarkInProgress()
-	// then
-	assert.Equal(t, spec, &BlueprintSpec{
-		Status: StatusPhaseInProgress,
-		Events: []Event{InProgressEvent{}},
+func TestBlueprintSpec_StartApplying(t *testing.T) {
+	t.Run("success without dry run", func(t *testing.T) {
+		// given
+		spec := &BlueprintSpec{}
+
+		// when
+		spec.StartApplying()
+
+		// then
+		assert.Equal(t, spec, &BlueprintSpec{
+			Status: StatusPhaseInProgress,
+			Events: []Event{InProgressEvent{}},
+		})
 	})
+
+	t.Run("should not change status and add dry run event", func(t *testing.T) {
+		// given
+		spec := &BlueprintSpec{
+			Status: StatusPhaseEcosystemHealthyUpfront,
+			Config: BlueprintConfiguration{
+				DryRun: true,
+			},
+		}
+
+		// when
+		spec.StartApplying()
+
+		// then
+		assert.Equal(t, spec, &BlueprintSpec{
+			Config: BlueprintConfiguration{
+				DryRun: true,
+			},
+			Status: StatusPhaseEcosystemHealthyUpfront,
+			Events: []Event{BlueprintDryRunEvent{}},
+		})
+	})
+
 }
 
 func TestBlueprintSpec_MarkFailed(t *testing.T) {

--- a/pkg/domain/blueprintSpec_test.go
+++ b/pkg/domain/blueprintSpec_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 )
 
-var version3_2_1_1, _ = core.ParseVersion("3.2.1-1")
-var version3_2_1_2, _ = core.ParseVersion("3.2.1-2")
-var version3_2_1_3, _ = core.ParseVersion("3.2.1-3")
+var version3211, _ = core.ParseVersion("3.2.1-1")
+var version3212, _ = core.ParseVersion("3.2.1-2")
+var version3213, _ = core.ParseVersion("3.2.1-3")
 
 func Test_BlueprintSpec_Validate_allOk(t *testing.T) {
 	spec := BlueprintSpec{Id: "29.11.2023"}
@@ -124,9 +124,9 @@ func Test_BlueprintSpec_validateMaskAgainstBlueprint_namespaceSwitchNotAllowed(t
 
 func Test_BlueprintSpec_CalculateEffectiveBlueprint_noMask(t *testing.T) {
 	dogus := []Dogu{
-		{Namespace: "official", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStatePresent},
-		{Namespace: "official", Name: "dogu2", Version: version3_2_1_2, TargetState: TargetStatePresent},
-		{Namespace: "absent", Name: "dogu3", Version: version3_2_1_3, TargetState: TargetStateAbsent},
+		{Namespace: "official", Name: "dogu1", Version: version3211, TargetState: TargetStatePresent},
+		{Namespace: "official", Name: "dogu2", Version: version3212, TargetState: TargetStatePresent},
+		{Namespace: "absent", Name: "dogu3", Version: version3213, TargetState: TargetStateAbsent},
 	}
 
 	spec := BlueprintSpec{
@@ -153,6 +153,18 @@ func Test_BlueprintSpec_CalculateEffectiveBlueprint_statusNew(t *testing.T) {
 	assert.ErrorContains(t, err, "cannot calculate effective blueprint before the blueprint spec is validated")
 }
 
+func Test_BlueprintSpec_CalculateEffectiveBlueprint_statusEffectiveBlueprintGenerated(t *testing.T) {
+	spec := BlueprintSpec{
+		Blueprint:     Blueprint{Dogus: []Dogu{}},
+		BlueprintMask: BlueprintMask{Dogus: []MaskDogu{}},
+		Status:        StatusPhaseEffectiveBlueprintGenerated,
+	}
+
+	err := spec.CalculateEffectiveBlueprint()
+
+	require.Nil(t, err)
+}
+
 func Test_BlueprintSpec_CalculateEffectiveBlueprint_statusInvalid(t *testing.T) {
 	spec := BlueprintSpec{
 		Blueprint:     Blueprint{Dogus: []Dogu{}},
@@ -168,13 +180,13 @@ func Test_BlueprintSpec_CalculateEffectiveBlueprint_statusInvalid(t *testing.T) 
 
 func Test_BlueprintSpec_CalculateEffectiveBlueprint_changeVersion(t *testing.T) {
 	dogus := []Dogu{
-		{Namespace: "official", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStatePresent},
-		{Namespace: "official", Name: "dogu2", Version: version3_2_1_2, TargetState: TargetStatePresent},
+		{Namespace: "official", Name: "dogu1", Version: version3211, TargetState: TargetStatePresent},
+		{Namespace: "official", Name: "dogu2", Version: version3212, TargetState: TargetStatePresent},
 	}
 
 	maskedDogus := []MaskDogu{
-		{Namespace: "official", Name: "dogu1", Version: version3_2_1_2, TargetState: TargetStatePresent},
-		{Namespace: "official", Name: "dogu2", Version: version3_2_1_1, TargetState: TargetStatePresent},
+		{Namespace: "official", Name: "dogu1", Version: version3212, TargetState: TargetStatePresent},
+		{Namespace: "official", Name: "dogu2", Version: version3211, TargetState: TargetStatePresent},
 	}
 
 	spec := BlueprintSpec{
@@ -186,18 +198,18 @@ func Test_BlueprintSpec_CalculateEffectiveBlueprint_changeVersion(t *testing.T) 
 
 	require.Nil(t, err)
 	require.Equal(t, 2, len(spec.EffectiveBlueprint.Dogus), "effective blueprint should contain the elements from the mask")
-	assert.Equal(t, Dogu{Namespace: "official", Name: "dogu1", Version: version3_2_1_2, TargetState: TargetStatePresent}, spec.EffectiveBlueprint.Dogus[0])
-	assert.Equal(t, Dogu{Namespace: "official", Name: "dogu2", Version: version3_2_1_1, TargetState: TargetStatePresent}, spec.EffectiveBlueprint.Dogus[1])
+	assert.Equal(t, Dogu{Namespace: "official", Name: "dogu1", Version: version3212, TargetState: TargetStatePresent}, spec.EffectiveBlueprint.Dogus[0])
+	assert.Equal(t, Dogu{Namespace: "official", Name: "dogu2", Version: version3211, TargetState: TargetStatePresent}, spec.EffectiveBlueprint.Dogus[1])
 }
 
 func Test_BlueprintSpec_CalculateEffectiveBlueprint_makeDoguAbsent(t *testing.T) {
 	dogus := []Dogu{
-		{Namespace: "official", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStatePresent},
-		{Namespace: "official", Name: "dogu2", Version: version3_2_1_2, TargetState: TargetStatePresent},
+		{Namespace: "official", Name: "dogu1", Version: version3211, TargetState: TargetStatePresent},
+		{Namespace: "official", Name: "dogu2", Version: version3212, TargetState: TargetStatePresent},
 	}
 
 	maskedDogus := []MaskDogu{
-		{Namespace: "official", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStateAbsent},
+		{Namespace: "official", Name: "dogu1", Version: version3211, TargetState: TargetStateAbsent},
 		{Namespace: "official", Name: "dogu2", TargetState: TargetStateAbsent},
 	}
 
@@ -210,8 +222,8 @@ func Test_BlueprintSpec_CalculateEffectiveBlueprint_makeDoguAbsent(t *testing.T)
 
 	require.Nil(t, err)
 	require.Equal(t, 2, len(spec.EffectiveBlueprint.Dogus), "effective blueprint should contain the elements from the mask")
-	assert.Equal(t, Dogu{Namespace: "official", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStateAbsent}, spec.EffectiveBlueprint.Dogus[0])
-	assert.Equal(t, Dogu{Namespace: "official", Name: "dogu2", Version: version3_2_1_2, TargetState: TargetStateAbsent}, spec.EffectiveBlueprint.Dogus[1])
+	assert.Equal(t, Dogu{Namespace: "official", Name: "dogu1", Version: version3211, TargetState: TargetStateAbsent}, spec.EffectiveBlueprint.Dogus[0])
+	assert.Equal(t, Dogu{Namespace: "official", Name: "dogu2", Version: version3212, TargetState: TargetStateAbsent}, spec.EffectiveBlueprint.Dogus[1])
 }
 
 func Test_BlueprintSpec_CalculateEffectiveBlueprint_makeAbsentDoguPresent(t *testing.T) {
@@ -220,7 +232,7 @@ func Test_BlueprintSpec_CalculateEffectiveBlueprint_makeAbsentDoguPresent(t *tes
 	}
 
 	maskedDogus := []MaskDogu{
-		{Namespace: "official", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStatePresent},
+		{Namespace: "official", Name: "dogu1", Version: version3211, TargetState: TargetStatePresent},
 	}
 
 	spec := BlueprintSpec{
@@ -232,17 +244,17 @@ func Test_BlueprintSpec_CalculateEffectiveBlueprint_makeAbsentDoguPresent(t *tes
 
 	require.Nil(t, err)
 	require.Equal(t, 1, len(spec.EffectiveBlueprint.Dogus), "effective blueprint should contain the elements from the mask")
-	//TODO: Is that the correct behavior? (absent dogus can be made present?)
-	assert.Equal(t, Dogu{Namespace: "official", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStatePresent}, spec.EffectiveBlueprint.Dogus[0])
+	// TODO: Is that the correct behavior? (absent dogus can be made present?)
+	assert.Equal(t, Dogu{Namespace: "official", Name: "dogu1", Version: version3211, TargetState: TargetStatePresent}, spec.EffectiveBlueprint.Dogus[0])
 }
 
 func Test_BlueprintSpec_CalculateEffectiveBlueprint_changeDoguNamespace(t *testing.T) {
 	dogus := []Dogu{
-		{Namespace: "official", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStatePresent},
+		{Namespace: "official", Name: "dogu1", Version: version3211, TargetState: TargetStatePresent},
 	}
 
 	maskedDogus := []MaskDogu{
-		{Namespace: "premium", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStatePresent},
+		{Namespace: "premium", Name: "dogu1", Version: version3211, TargetState: TargetStatePresent},
 	}
 
 	spec := BlueprintSpec{
@@ -259,11 +271,11 @@ func Test_BlueprintSpec_CalculateEffectiveBlueprint_changeDoguNamespace(t *testi
 
 func Test_BlueprintSpec_CalculateEffectiveBlueprint_changeDoguNamespaceWithFlag(t *testing.T) {
 	dogus := []Dogu{
-		{Namespace: "official", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStatePresent},
+		{Namespace: "official", Name: "dogu1", Version: version3211, TargetState: TargetStatePresent},
 	}
 
 	maskedDogus := []MaskDogu{
-		{Namespace: "premium", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStatePresent},
+		{Namespace: "premium", Name: "dogu1", Version: version3211, TargetState: TargetStatePresent},
 	}
 
 	spec := BlueprintSpec{
@@ -276,7 +288,7 @@ func Test_BlueprintSpec_CalculateEffectiveBlueprint_changeDoguNamespaceWithFlag(
 
 	require.Nil(t, err, "with the feature flag namespace changes should be allowed")
 	require.Equal(t, 1, len(spec.EffectiveBlueprint.Dogus), "effective blueprint should contain the elements from the mask")
-	assert.Equal(t, Dogu{Namespace: "premium", Name: "dogu1", Version: version3_2_1_1, TargetState: TargetStatePresent}, spec.EffectiveBlueprint.Dogus[0])
+	assert.Equal(t, Dogu{Namespace: "premium", Name: "dogu1", Version: version3211, TargetState: TargetStatePresent}, spec.EffectiveBlueprint.Dogus[0])
 }
 
 func TestBlueprintSpec_MarkInvalid(t *testing.T) {
@@ -299,7 +311,7 @@ func TestBlueprintSpec_DetermineStateDiff(t *testing.T) {
 	// not every single case is tested here as this is a rather coarse-grained function
 	// have a look at the tests for the more specialized functions used in the command, to see all possible combinations of diffs.
 	t.Run("all ok with empty blueprint", func(t *testing.T) {
-		//given
+		// given
 		spec := BlueprintSpec{
 			EffectiveBlueprint: EffectiveBlueprint{
 				Dogus:                   []Dogu{},
@@ -313,10 +325,10 @@ func TestBlueprintSpec_DetermineStateDiff(t *testing.T) {
 
 		installedDogus := map[string]*ecosystem.DoguInstallation{}
 
-		//when
+		// when
 		err := spec.DetermineStateDiff(installedDogus)
 
-		//then
+		// then
 		stateDiff := StateDiff{DoguDiffs: []DoguDiff{}}
 		require.NoError(t, err)
 		assert.Equal(t, StatusPhaseStateDiffDetermined, spec.Status)
@@ -328,15 +340,15 @@ func TestBlueprintSpec_DetermineStateDiff(t *testing.T) {
 	notAllowedStatus := []StatusPhase{StatusPhaseNew, StatusPhaseStaticallyValidated, StatusPhaseEffectiveBlueprintGenerated}
 	for _, initialStatus := range notAllowedStatus {
 		t.Run(fmt.Sprintf("cannot determine state diff in status %q", initialStatus), func(t *testing.T) {
-			//given
+			// given
 			spec := BlueprintSpec{
 				Status: initialStatus,
 			}
 			installedDogus := map[string]*ecosystem.DoguInstallation{}
-			//when
+			// when
 			err := spec.DetermineStateDiff(installedDogus)
 
-			//then
+			// then
 			assert.Error(t, err)
 			assert.Equal(t, spec.Status, initialStatus)
 			require.Equal(t, 0, len(spec.Events))
@@ -345,15 +357,15 @@ func TestBlueprintSpec_DetermineStateDiff(t *testing.T) {
 	}
 	t.Run("do not re-determine state diff", func(t *testing.T) {
 		initialStatus := StatusPhaseCompleted
-		//given
+		// given
 		spec := BlueprintSpec{
 			Status: initialStatus,
 		}
 		installedDogus := map[string]*ecosystem.DoguInstallation{}
-		//when
+		// when
 		err := spec.DetermineStateDiff(installedDogus)
 
-		//then
+		// then
 		assert.NoError(t, err)
 		assert.Equal(t, spec.Status, initialStatus)
 		require.Equal(t, 0, len(spec.Events))
@@ -471,11 +483,11 @@ func TestBlueprintSpec_CheckEcosystemHealthAfterwards(t *testing.T) {
 }
 
 func TestBlueprintSpec_MarkInProgress(t *testing.T) {
-	//given
+	// given
 	spec := &BlueprintSpec{}
-	//when
+	// when
 	spec.MarkInProgress()
-	//then
+	// then
 	assert.Equal(t, spec, &BlueprintSpec{
 		Status: StatusPhaseInProgress,
 		Events: []Event{InProgressEvent{}},
@@ -483,12 +495,12 @@ func TestBlueprintSpec_MarkInProgress(t *testing.T) {
 }
 
 func TestBlueprintSpec_MarkFailed(t *testing.T) {
-	//given
+	// given
 	spec := &BlueprintSpec{}
 	err := fmt.Errorf("test-error")
-	//when
+	// when
 	spec.MarkFailed(err)
-	//then
+	// then
 	assert.Equal(t, spec, &BlueprintSpec{
 		Status: StatusPhaseFailed,
 		Events: []Event{ExecutionFailedEvent{err: err}},
@@ -496,11 +508,11 @@ func TestBlueprintSpec_MarkFailed(t *testing.T) {
 }
 
 func TestBlueprintSpec_MarkBlueprintApplied(t *testing.T) {
-	//given
+	// given
 	spec := &BlueprintSpec{}
-	//when
+	// when
 	spec.MarkBlueprintApplied()
-	//then
+	// then
 	assert.Equal(t, spec, &BlueprintSpec{
 		Status: StatusPhaseBlueprintApplied,
 		Events: []Event{BlueprintAppliedEvent{}},
@@ -508,13 +520,61 @@ func TestBlueprintSpec_MarkBlueprintApplied(t *testing.T) {
 }
 
 func TestBlueprintSpec_MarkCompleted(t *testing.T) {
-	//given
+	// given
 	spec := &BlueprintSpec{}
-	//when
+	// when
 	spec.MarkCompleted()
-	//then
+	// then
 	assert.Equal(t, spec, &BlueprintSpec{
 		Status: StatusPhaseCompleted,
 		Events: []Event{CompletedEvent{}},
 	})
+}
+
+func TestBlueprintSpec_ValidateDynamically(t *testing.T) {
+	type fields struct {
+		Id                   string
+		Blueprint            Blueprint
+		BlueprintMask        BlueprintMask
+		EffectiveBlueprint   EffectiveBlueprint
+		StateDiff            StateDiff
+		BlueprintUpgradePlan BlueprintUpgradePlan
+		Config               BlueprintConfiguration
+		Status               StatusPhase
+		PersistenceContext   map[string]interface{}
+		Events               []Event
+	}
+	type args struct {
+		possibleInvalidDependenciesError error
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		expectedPhase  StatusPhase
+		expectedEvents []Event
+	}{
+		{name: "statusphase invalid on error", fields: fields{}, args: args{possibleInvalidDependenciesError: assert.AnError}, expectedPhase: "invalid", expectedEvents: []Event{BlueprintSpecInvalidEvent{ValidationError: &InvalidBlueprintError{WrappedError: assert.AnError, Message: "blueprint spec is invalid"}}}},
+		{name: "statusphase valid on nil", fields: fields{}, args: args{possibleInvalidDependenciesError: nil}, expectedPhase: "validated", expectedEvents: []Event{BlueprintSpecValidatedEvent{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &BlueprintSpec{
+				Id:                   tt.fields.Id,
+				Blueprint:            tt.fields.Blueprint,
+				BlueprintMask:        tt.fields.BlueprintMask,
+				EffectiveBlueprint:   tt.fields.EffectiveBlueprint,
+				StateDiff:            tt.fields.StateDiff,
+				BlueprintUpgradePlan: tt.fields.BlueprintUpgradePlan,
+				Config:               tt.fields.Config,
+				Status:               tt.fields.Status,
+				PersistenceContext:   tt.fields.PersistenceContext,
+				Events:               tt.fields.Events,
+			}
+			spec.ValidateDynamically(tt.args.possibleInvalidDependenciesError)
+
+			assert.Equal(t, tt.expectedPhase, spec.Status)
+			assert.Equal(t, tt.expectedEvents, spec.Events)
+		})
+	}
 }

--- a/pkg/domain/blueprintSpec_test.go
+++ b/pkg/domain/blueprintSpec_test.go
@@ -554,8 +554,22 @@ func TestBlueprintSpec_ValidateDynamically(t *testing.T) {
 		expectedPhase  StatusPhase
 		expectedEvents []Event
 	}{
-		{name: "statusphase invalid on error", fields: fields{}, args: args{possibleInvalidDependenciesError: assert.AnError}, expectedPhase: "invalid", expectedEvents: []Event{BlueprintSpecInvalidEvent{ValidationError: &InvalidBlueprintError{WrappedError: assert.AnError, Message: "blueprint spec is invalid"}}}},
-		{name: "statusphase valid on nil", fields: fields{}, args: args{possibleInvalidDependenciesError: nil}, expectedPhase: "validated", expectedEvents: []Event{BlueprintSpecValidatedEvent{}}},
+		{
+			name:          "statusphase invalid on error",
+			fields:        fields{},
+			args:          args{possibleInvalidDependenciesError: assert.AnError},
+			expectedPhase: "invalid",
+			expectedEvents: []Event{BlueprintSpecInvalidEvent{
+				ValidationError: &InvalidBlueprintError{WrappedError: assert.AnError, Message: "blueprint spec is invalid"}},
+			},
+		},
+		{
+			name:           "statusphase valid on nil",
+			fields:         fields{},
+			args:           args{possibleInvalidDependenciesError: nil},
+			expectedPhase:  "validated",
+			expectedEvents: []Event{BlueprintSpecValidatedEvent{}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/domain/blueprintSpec_test.go
+++ b/pkg/domain/blueprintSpec_test.go
@@ -159,10 +159,12 @@ func Test_BlueprintSpec_CalculateEffectiveBlueprint_statusEffectiveBlueprintGene
 		BlueprintMask: BlueprintMask{Dogus: []MaskDogu{}},
 		Status:        StatusPhaseEffectiveBlueprintGenerated,
 	}
+	expectedSpec := spec
 
 	err := spec.CalculateEffectiveBlueprint()
 
 	require.Nil(t, err)
+	assert.Equal(t, expectedSpec, spec)
 }
 
 func Test_BlueprintSpec_CalculateEffectiveBlueprint_statusInvalid(t *testing.T) {

--- a/pkg/domain/blueprint_test.go
+++ b/pkg/domain/blueprint_test.go
@@ -15,14 +15,14 @@ func Test_validate_ok(t *testing.T) {
 		{Namespace: "absent", Name: "dogu1", Version: version3_2_1_0, TargetState: TargetStateAbsent},
 		{Namespace: "absent", Name: "dogu2", TargetState: TargetStateAbsent},
 		{Namespace: "present", Name: "dogu3", Version: version3_2_1_0, TargetState: TargetStatePresent},
-		{Namespace: "present", Name: "dogu4", Version: version3_2_1_3},
+		{Namespace: "present", Name: "dogu4", Version: version3213},
 	}
 
 	components := []Component{
 		{Name: "absent/component1", Version: version3_2_1_0, TargetState: TargetStateAbsent},
 		{Name: "absent/component2", TargetState: TargetStateAbsent},
-		{Name: "present-component3", Version: version3_2_1_2, TargetState: TargetStatePresent},
-		{Name: "present/component4", Version: version3_2_1_3},
+		{Name: "present-component3", Version: version3212, TargetState: TargetStatePresent},
+		{Name: "present/component4", Version: version3213},
 	}
 	blueprint := Blueprint{Dogus: dogus, Components: components}
 
@@ -32,10 +32,10 @@ func Test_validate_ok(t *testing.T) {
 }
 func Test_validate_multipleErrors(t *testing.T) {
 	dogus := []Dogu{
-		{Version: version3_2_1_2},
+		{Version: version3212},
 	}
 	components := []Component{
-		{Version: version3_2_1_2},
+		{Version: version3212},
 	}
 	blueprint := Blueprint{Dogus: dogus, Components: components}
 
@@ -51,8 +51,8 @@ func Test_validateDogus_ok(t *testing.T) {
 	dogus := []Dogu{
 		{Namespace: "absent", Name: "dogu", Version: version3_2_1_4, TargetState: TargetStateAbsent},
 		{Namespace: "absent", Name: "versionIsOptionalForStateAbsent", TargetState: TargetStateAbsent},
-		{Namespace: "present", Name: "dogu", Version: version3_2_1_2, TargetState: TargetStatePresent},
-		{Namespace: "present", Name: "StateDefaultsToPresent", Version: version3_2_1_2},
+		{Namespace: "present", Name: "dogu", Version: version3212, TargetState: TargetStatePresent},
+		{Namespace: "present", Name: "StateDefaultsToPresent", Version: version3212},
 	}
 	blueprint := Blueprint{Dogus: dogus}
 
@@ -64,7 +64,7 @@ func Test_validateDogus_ok(t *testing.T) {
 func Test_validateDogus_multipleErrors(t *testing.T) {
 	dogus := []Dogu{
 		{Name: "test"},
-		{Version: version3_2_1_2},
+		{Version: version3212},
 	}
 	blueprint := Blueprint{Dogus: dogus}
 
@@ -78,7 +78,7 @@ func Test_validateDogus_multipleErrors(t *testing.T) {
 func Test_validateComponents_ok(t *testing.T) {
 	components := []Component{
 		{Name: "absent-component", TargetState: TargetStateAbsent},
-		{Name: "present-component", Version: version3_2_1_2, TargetState: TargetStatePresent},
+		{Name: "present-component", Version: version3212, TargetState: TargetStatePresent},
 	}
 	blueprint := Blueprint{Components: components}
 
@@ -90,7 +90,7 @@ func Test_validateComponents_ok(t *testing.T) {
 func Test_validateComponents_multipleErrors(t *testing.T) {
 	components := []Component{
 		{Name: "test"},
-		{Version: version3_2_1_2},
+		{Version: version3212},
 	}
 	blueprint := Blueprint{Components: components}
 	err := blueprint.validateComponents()
@@ -103,9 +103,9 @@ func Test_validateComponents_multipleErrors(t *testing.T) {
 func Test_validateDoguUniqueness(t *testing.T) {
 	dogus := []Dogu{
 		{Name: "present/dogu1", Version: version3_2_1_0, TargetState: TargetStatePresent},
-		{Name: "present/dogu1", Version: version3_2_1_3},
-		{Name: "present/dogu2", Version: version3_2_1_3},
-		{Name: "present/dogu2", Version: version3_2_1_3},
+		{Name: "present/dogu1", Version: version3213},
+		{Name: "present/dogu2", Version: version3213},
+		{Name: "present/dogu2", Version: version3213},
 	}
 
 	blueprint := Blueprint{Dogus: dogus}
@@ -121,9 +121,9 @@ func Test_validateDoguUniqueness(t *testing.T) {
 func Test_validateComponentUniqueness(t *testing.T) {
 	components := []Component{
 		{Name: "present/component1", Version: version3_2_1_0, TargetState: TargetStatePresent},
-		{Name: "present/component1", Version: version3_2_1_3},
-		{Name: "present/component2", Version: version3_2_1_3},
-		{Name: "present/component2", Version: version3_2_1_3},
+		{Name: "present/component1", Version: version3213},
+		{Name: "present/component2", Version: version3213},
+		{Name: "present/component2", Version: version3213},
 	}
 
 	blueprint := Blueprint{Components: components}
@@ -172,8 +172,8 @@ func TestSetDoguRegistryKeysSuccessful(t *testing.T) {
 	dogu3 := map[string]interface{}{"keyDogu3": "valDogu3"}
 	dogus := []Dogu{
 		{Namespace: "present", Name: "dogu1", Version: version3_2_1_0, TargetState: TargetStatePresent},
-		{Namespace: "present", Name: "dogu2", Version: version3_2_1_3, TargetState: TargetStatePresent},
-		{Namespace: "present", Name: "dogu3", Version: version3_2_1_3, TargetState: TargetStatePresent},
+		{Namespace: "present", Name: "dogu2", Version: version3213, TargetState: TargetStatePresent},
+		{Namespace: "present", Name: "dogu3", Version: version3213, TargetState: TargetStatePresent},
 	}
 
 	blueprint := Blueprint{

--- a/pkg/domain/dogu_test.go
+++ b/pkg/domain/dogu_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test_TargetDogu_validate_errorOnMissingDoguName(t *testing.T) {
 	dogus := []Dogu{
-		{Version: version3_2_1_2, TargetState: TargetStatePresent},
+		{Version: version3212, TargetState: TargetStatePresent},
 	}
 	blueprint := Blueprint{Dogus: dogus}
 
@@ -19,7 +19,7 @@ func Test_TargetDogu_validate_errorOnMissingDoguName(t *testing.T) {
 }
 
 func Test_TargetDogu_validate_errorOnEmptyDoguName(t *testing.T) {
-	dogu := Dogu{Name: "", Version: version3_2_1_2, TargetState: TargetStatePresent}
+	dogu := Dogu{Name: "", Version: version3212, TargetState: TargetStatePresent}
 
 	err := dogu.validate()
 

--- a/pkg/domain/events.go
+++ b/pkg/domain/events.go
@@ -17,7 +17,7 @@ func (b BlueprintDryRunEvent) Name() string {
 }
 
 func (b BlueprintDryRunEvent) Message() string {
-	return "Executing blueprint in dry run mode"
+	return "Executed blueprint in dry run mode"
 }
 
 type BlueprintSpecInvalidEvent struct {

--- a/pkg/domain/events.go
+++ b/pkg/domain/events.go
@@ -10,6 +10,16 @@ type Event interface {
 	Message() string
 }
 
+type BlueprintDryRunEvent struct{}
+
+func (b BlueprintDryRunEvent) Name() string {
+	return "BlueprintDryRun"
+}
+
+func (b BlueprintDryRunEvent) Message() string {
+	return fmt.Sprintf("Executing blueprint in dry run mode")
+}
+
 type BlueprintSpecInvalidEvent struct {
 	ValidationError error
 }

--- a/pkg/domain/events.go
+++ b/pkg/domain/events.go
@@ -17,7 +17,7 @@ func (b BlueprintDryRunEvent) Name() string {
 }
 
 func (b BlueprintDryRunEvent) Message() string {
-	return fmt.Sprintf("Executing blueprint in dry run mode")
+	return "Executing blueprint in dry run mode"
 }
 
 type BlueprintSpecInvalidEvent struct {

--- a/pkg/domain/events_test.go
+++ b/pkg/domain/events_test.go
@@ -15,6 +15,12 @@ func TestEvents(t *testing.T) {
 		expectedMessage string
 	}{
 		{
+			name:            "blueprint dry run",
+			event:           BlueprintDryRunEvent{},
+			expectedName:    "BlueprintDryRun",
+			expectedMessage: "Executing blueprint in dry run mode",
+		},
+		{
 			name:            "blueprint spec invalid",
 			event:           BlueprintSpecInvalidEvent{ValidationError: assert.AnError},
 			expectedName:    "BlueprintSpecInvalid",

--- a/pkg/domain/events_test.go
+++ b/pkg/domain/events_test.go
@@ -18,7 +18,7 @@ func TestEvents(t *testing.T) {
 			name:            "blueprint dry run",
 			event:           BlueprintDryRunEvent{},
 			expectedName:    "BlueprintDryRun",
-			expectedMessage: "Executing blueprint in dry run mode",
+			expectedMessage: "Executed blueprint in dry run mode",
 		},
 		{
 			name:            "blueprint spec invalid",

--- a/pkg/domain/stateDiff_test.go
+++ b/pkg/domain/stateDiff_test.go
@@ -22,25 +22,25 @@ func Test_determineDoguDiff(t *testing.T) {
 				blueprintDogu: &Dogu{
 					Namespace:   "official",
 					Name:        "postgresql",
-					Version:     version3_2_1_1,
+					Version:     version3211,
 					TargetState: TargetStatePresent,
 				},
 				installedDogu: &ecosystem.DoguInstallation{
 					Namespace: "official",
 					Name:      "postgresql",
-					Version:   version3_2_1_1,
+					Version:   version3211,
 				},
 			},
 			want: DoguDiff{
 				DoguName: "postgresql",
 				Actual: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_1,
+					Version:           version3211,
 					InstallationState: TargetStatePresent,
 				},
 				Expected: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_1,
+					Version:           version3211,
 					InstallationState: TargetStatePresent,
 				},
 				NeededAction: ActionNone,
@@ -52,7 +52,7 @@ func Test_determineDoguDiff(t *testing.T) {
 				blueprintDogu: &Dogu{
 					Namespace:   "official",
 					Name:        "postgresql",
-					Version:     version3_2_1_1,
+					Version:     version3211,
 					TargetState: TargetStatePresent,
 				},
 				installedDogu: nil,
@@ -64,7 +64,7 @@ func Test_determineDoguDiff(t *testing.T) {
 				},
 				Expected: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_1,
+					Version:           version3211,
 					InstallationState: TargetStatePresent,
 				},
 				NeededAction: ActionInstall,
@@ -80,14 +80,14 @@ func Test_determineDoguDiff(t *testing.T) {
 				installedDogu: &ecosystem.DoguInstallation{
 					Namespace: "official",
 					Name:      "postgresql",
-					Version:   version3_2_1_1,
+					Version:   version3211,
 				},
 			},
 			want: DoguDiff{
 				DoguName: "postgresql",
 				Actual: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_1,
+					Version:           version3211,
 					InstallationState: TargetStatePresent,
 				},
 				Expected: DoguDiffState{
@@ -102,25 +102,25 @@ func Test_determineDoguDiff(t *testing.T) {
 				blueprintDogu: &Dogu{
 					Namespace:   "premium",
 					Name:        "postgresql",
-					Version:     version3_2_1_1,
+					Version:     version3211,
 					TargetState: TargetStatePresent,
 				},
 				installedDogu: &ecosystem.DoguInstallation{
 					Namespace: "official",
 					Name:      "postgresql",
-					Version:   version3_2_1_1,
+					Version:   version3211,
 				},
 			},
 			want: DoguDiff{
 				DoguName: "postgresql",
 				Actual: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_1,
+					Version:           version3211,
 					InstallationState: TargetStatePresent,
 				},
 				Expected: DoguDiffState{
 					Namespace:         "premium",
-					Version:           version3_2_1_1,
+					Version:           version3211,
 					InstallationState: TargetStatePresent,
 				},
 				NeededAction: ActionSwitchNamespace,
@@ -132,25 +132,25 @@ func Test_determineDoguDiff(t *testing.T) {
 				blueprintDogu: &Dogu{
 					Namespace:   "official",
 					Name:        "postgresql",
-					Version:     version3_2_1_2,
+					Version:     version3212,
 					TargetState: TargetStatePresent,
 				},
 				installedDogu: &ecosystem.DoguInstallation{
 					Namespace: "official",
 					Name:      "postgresql",
-					Version:   version3_2_1_1,
+					Version:   version3211,
 				},
 			},
 			want: DoguDiff{
 				DoguName: "postgresql",
 				Actual: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_1,
+					Version:           version3211,
 					InstallationState: TargetStatePresent,
 				},
 				Expected: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_2,
+					Version:           version3212,
 					InstallationState: TargetStatePresent,
 				},
 				NeededAction: ActionUpgrade,
@@ -162,25 +162,25 @@ func Test_determineDoguDiff(t *testing.T) {
 				blueprintDogu: &Dogu{
 					Namespace:   "official",
 					Name:        "postgresql",
-					Version:     version3_2_1_1,
+					Version:     version3211,
 					TargetState: TargetStatePresent,
 				},
 				installedDogu: &ecosystem.DoguInstallation{
 					Namespace: "official",
 					Name:      "postgresql",
-					Version:   version3_2_1_2,
+					Version:   version3212,
 				},
 			},
 			want: DoguDiff{
 				DoguName: "postgresql",
 				Actual: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_2,
+					Version:           version3212,
 					InstallationState: TargetStatePresent,
 				},
 				Expected: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_1,
+					Version:           version3211,
 					InstallationState: TargetStatePresent,
 				},
 				NeededAction: ActionDowngrade,
@@ -193,19 +193,19 @@ func Test_determineDoguDiff(t *testing.T) {
 				installedDogu: &ecosystem.DoguInstallation{
 					Namespace: "official",
 					Name:      "postgresql",
-					Version:   version3_2_1_1,
+					Version:   version3211,
 				},
 			},
 			want: DoguDiff{
 				DoguName: "postgresql",
 				Actual: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_1,
+					Version:           version3211,
 					InstallationState: TargetStatePresent,
 				},
 				Expected: DoguDiffState{
 					Namespace:         "official",
-					Version:           version3_2_1_1,
+					Version:           version3211,
 					InstallationState: TargetStatePresent,
 				},
 				NeededAction: ActionNone,
@@ -261,7 +261,7 @@ func Test_determineDoguDiffs(t *testing.T) {
 					{
 						Namespace:   "official",
 						Name:        "postgresql",
-						Version:     version3_2_1_1,
+						Version:     version3211,
 						TargetState: TargetStatePresent,
 					},
 				},
@@ -275,7 +275,7 @@ func Test_determineDoguDiffs(t *testing.T) {
 					},
 					Expected: DoguDiffState{
 						Namespace:         "official",
-						Version:           version3_2_1_1,
+						Version:           version3211,
 						InstallationState: TargetStatePresent,
 					},
 					NeededAction: ActionInstall,
@@ -290,7 +290,7 @@ func Test_determineDoguDiffs(t *testing.T) {
 					"postgresql": {
 						Namespace: "official",
 						Name:      "postgresql",
-						Version:   version3_2_1_1,
+						Version:   version3211,
 					},
 				},
 			},
@@ -299,12 +299,12 @@ func Test_determineDoguDiffs(t *testing.T) {
 					DoguName: "postgresql",
 					Actual: DoguDiffState{
 						Namespace:         "official",
-						Version:           version3_2_1_1,
+						Version:           version3211,
 						InstallationState: TargetStatePresent,
 					},
 					Expected: DoguDiffState{
 						Namespace:         "official",
-						Version:           version3_2_1_1,
+						Version:           version3211,
 						InstallationState: TargetStatePresent,
 					},
 					NeededAction: ActionNone,
@@ -318,7 +318,7 @@ func Test_determineDoguDiffs(t *testing.T) {
 					{
 						Namespace:   "official",
 						Name:        "postgresql",
-						Version:     version3_2_1_2,
+						Version:     version3212,
 						TargetState: TargetStatePresent,
 					},
 				},
@@ -326,7 +326,7 @@ func Test_determineDoguDiffs(t *testing.T) {
 					"postgresql": {
 						Namespace: "official",
 						Name:      "postgresql",
-						Version:   version3_2_1_1,
+						Version:   version3211,
 					},
 				},
 			},
@@ -335,12 +335,12 @@ func Test_determineDoguDiffs(t *testing.T) {
 					DoguName: "postgresql",
 					Actual: DoguDiffState{
 						Namespace:         "official",
-						Version:           version3_2_1_1,
+						Version:           version3211,
 						InstallationState: TargetStatePresent,
 					},
 					Expected: DoguDiffState{
 						Namespace:         "official",
-						Version:           version3_2_1_2,
+						Version:           version3212,
 						InstallationState: TargetStatePresent,
 					},
 					NeededAction: ActionUpgrade,
@@ -408,12 +408,12 @@ func TestDoguDiffs_Statistics(t *testing.T) {
 func TestDoguDiff_String(t *testing.T) {
 	actual := DoguDiffState{
 		Namespace:         "official",
-		Version:           version3_2_1_1,
+		Version:           version3211,
 		InstallationState: TargetStatePresent,
 	}
 	expected := DoguDiffState{
 		Namespace:         "premium",
-		Version:           version3_2_1_2,
+		Version:           version3212,
 		InstallationState: TargetStatePresent,
 	}
 	diff := &DoguDiff{
@@ -433,7 +433,7 @@ func TestDoguDiff_String(t *testing.T) {
 func TestDoguDiffState_String(t *testing.T) {
 	diff := &DoguDiffState{
 		Namespace:         "official",
-		Version:           version3_2_1_1,
+		Version:           version3211,
 		InstallationState: TargetStatePresent,
 	}
 

--- a/samples/k8s_v1_blueprint_dry_run.yaml
+++ b/samples/k8s_v1_blueprint_dry_run.yaml
@@ -1,0 +1,17 @@
+apiVersion: k8s.cloudogu.com/v1
+kind: Blueprint
+metadata:
+  labels:
+    app.kubernetes.io/name: blueprint
+    app.kubernetes.io/instance: blueprint-sample
+    app.kubernetes.io/part-of: k8s-blueprint-operator
+    app.kubernetes.io/created-by: k8s-blueprint-operator
+  name: blueprint-sample-dry-run
+spec:
+  blueprint: |
+    {"blueprintApi":"v2","dogus":[{"name":"official/postgresql","version":"12.15-2","targetState":"present"}]}
+  blueprintMask: |
+    {"blueprintMaskApi":"v1"}
+  ignoreDoguHealth: false
+  allowDoguNamespaceSwitch: false
+  dryRun: true


### PR DESCRIPTION
Add `dryRun` option. If `dryRun` is active the blueprint procedure stops before applying resources to the cluster and remains in the actual state. One can set the option to false and continue at this state.

Resolves #22 