### PR TITLE
Make dogu config or sensitiveConfig not required if one of them is specified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,7 @@ Config-specific:
 - [#36] Set registry configuration for dogu and global config.
 - [#38] Censor all sensitive configuration data after applying the blueprint
 - [#45] Set registry configuration for encrypted values.
+
+### Fixed
+
+- [68] Make dogu config or sensitiveConfig not required if one of them is specified.

--- a/k8s/helm-crd/templates/k8s.cloudogu.com_blueprints.yaml
+++ b/k8s/helm-crd/templates/k8s.cloudogu.com_blueprints.yaml
@@ -290,9 +290,6 @@ spec:
                                 - neededAction
                               type: object
                             type: array
-                        required:
-                          - doguConfigDiff
-                          - sensitiveDoguConfigDiff
                         type: object
                       description: DoguConfigDiffs maps simple dogu names to the determined config diff.
                       type: object

--- a/pkg/adapter/kubernetes/blueprintcr/v1/doguConfigDiff.go
+++ b/pkg/adapter/kubernetes/blueprintcr/v1/doguConfigDiff.go
@@ -6,8 +6,8 @@ import (
 )
 
 type CombinedDoguConfigDiff struct {
-	DoguConfigDiff          DoguConfigDiff          `json:"doguConfigDiff"`
-	SensitiveDoguConfigDiff SensitiveDoguConfigDiff `json:"sensitiveDoguConfigDiff"`
+	DoguConfigDiff          DoguConfigDiff          `json:"doguConfigDiff,omitempty"`
+	SensitiveDoguConfigDiff SensitiveDoguConfigDiff `json:"sensitiveDoguConfigDiff,omitempty"`
 }
 
 type DoguConfigValueState ConfigValueState


### PR DESCRIPTION
Resolves #68 