### PR TITLE
Add volume mount for dogu registry cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [71] Add optional volume mount for self-signed certificate for the dogu registry.
 
 ## [v0.1.0] - 2024-03-20
 ### Added

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -99,9 +99,18 @@ spec:
               drop:
                 - ALL
           imagePullPolicy: {{ .Values.manager.imagePullPolicy }}
+          volumeMounts:
+            - mountPath: /etc/ssl/certs/dogu-registry-cert.pem
+              name: dogu-registry-cert
+              subPath: dogu-registry-cert.pem
       securityContext:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: {{ include "k8s-blueprint-operator.name" . }}-controller-manager
       terminationGracePeriodSeconds: 10
+      volumes:
+        - name: dogu-registry-cert
+          secret:
+            optional: true
+            secretName: {{ .Values.doguRegistry.certificate.secret }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -33,3 +33,6 @@ healthConfig:
   wait:
     timeout: 10m
     interval: 10s
+doguRegistry:
+  certificate:
+    secret: dogu-registry-cert

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ import (
 	k8sv1 "github.com/cloudogu/k8s-blueprint-operator/pkg/adapter/kubernetes/blueprintcr/v1"
 	"github.com/cloudogu/k8s-blueprint-operator/pkg/adapter/reconciler"
 	"github.com/cloudogu/k8s-blueprint-operator/pkg/config"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 var (
@@ -49,7 +49,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(k8sv1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 func main() {


### PR DESCRIPTION
This mount is needed because in dev environments the dogu registry always contains a self-signed certificate.
Without the mount the blueprint-operator throws an error querying dogu jsons.

Resolves #71 